### PR TITLE
docs: added reference to Pulsar official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Exein Layer for Yocto
-This layer contains Pulsar and kernel recipes to add the Pulsar security framework to an image.
+This layer contains Pulsar and kernel recipes to add the [Pulsar](https://github.com/Exein-io/pulsar) security framework to an image.
 
 > **Note:** `meta-exein` is tested only on Yocto Kirkstone, Langdale, Mickledore and Nanbield.
 


### PR DESCRIPTION
added reference to Pulsar.

Feel free to add more as you see fit. It's important that it is clear that meta-exein refers to Pulsar, with all the related documentation and what not.